### PR TITLE
Add hard-coded header colors suggested by @okets in #42

### DIFF
--- a/create-themes.py
+++ b/create-themes.py
@@ -25,6 +25,7 @@ def average_color(fname):
 
 
 BACKGROUND_COLORS = {
+    # Suggested by @okets in issue #42
     "blue-red": "rgba(30, 2, 61, 0.4)",
     "dark-blue": "rgba(48, 69, 124, 0.4)",
     "dark-green": "rgba(48, 89, 71, 0.4)",

--- a/create-themes.py
+++ b/create-themes.py
@@ -24,6 +24,17 @@ def average_color(fname):
     return "rgba({}, {}, {}, 0.4)".format(*rgb_color)
 
 
+BACKGROUND_COLORS = {
+    "blue-red": "rgba(30, 2, 61, 0.4)",
+    "dark-blue": "rgba(48, 69, 124, 0.4)",
+    "dark-green": "rgba(48, 89, 71, 0.4)",
+    "light-blue": "rgba(1, 195, 220, 0.4)",
+    "light-green": "rgba(114, 188, 139, 0.4)",
+    "orange": "rgba(255, 229, 116, 0.4)",
+    "red": "rgba(234, 88, 63, 0.4)",
+}
+
+
 folder_fname = [
     ("hacsfiles", Path("themes/ios-themes.yaml")),
     ("local", Path("manual-install/ios-themes.yaml")),
@@ -34,7 +45,10 @@ for folder, fname in folder_fname:
         f.write("---\n# From https://github.com/basnijholt/lovelace-ios-themes")
     for background in Path("themes").glob("homekit-bg-*.jpg"):
         color = background.stem.split("homekit-bg-")[-1]
-        app_header_background_color = average_color(background)
+        if color in BACKGROUND_COLORS:
+            app_header_background_color = BACKGROUND_COLORS[color]
+        else:
+            app_header_background_color = average_color(background)
         for which in ["light", "dark"]:
             for state_icon_yellow in [False, True]:
                 settings = {k: parse(v[which]) for k, v in all_settings.items()}

--- a/manual-install/ios-themes.yaml
+++ b/manual-install/ios-themes.yaml
@@ -68,7 +68,7 @@ ios-light-mode-dark-green-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(61, 107, 86, 0.4)
+  app-header-background-color: rgba(48, 89, 71, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -155,7 +155,7 @@ ios-light-mode-dark-green:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(61, 107, 86, 0.4)
+  app-header-background-color: rgba(48, 89, 71, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -242,7 +242,7 @@ ios-dark-mode-dark-green-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(61, 107, 86, 0.4)
+  app-header-background-color: rgba(48, 89, 71, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -329,7 +329,7 @@ ios-dark-mode-dark-green:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(61, 107, 86, 0.4)
+  app-header-background-color: rgba(48, 89, 71, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -416,7 +416,7 @@ ios-light-mode-light-blue-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(1, 133, 162, 0.4)
+  app-header-background-color: rgba(1, 195, 220, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -503,7 +503,7 @@ ios-light-mode-light-blue:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(1, 133, 162, 0.4)
+  app-header-background-color: rgba(1, 195, 220, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -590,7 +590,7 @@ ios-dark-mode-light-blue-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(1, 133, 162, 0.4)
+  app-header-background-color: rgba(1, 195, 220, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -677,7 +677,7 @@ ios-dark-mode-light-blue:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(1, 133, 162, 0.4)
+  app-header-background-color: rgba(1, 195, 220, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -764,7 +764,7 @@ ios-light-mode-light-green-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(116, 184, 139, 0.4)
+  app-header-background-color: rgba(114, 188, 139, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -851,7 +851,7 @@ ios-light-mode-light-green:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(116, 184, 139, 0.4)
+  app-header-background-color: rgba(114, 188, 139, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -938,7 +938,7 @@ ios-dark-mode-light-green-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(116, 184, 139, 0.4)
+  app-header-background-color: rgba(114, 188, 139, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -1025,7 +1025,7 @@ ios-dark-mode-light-green:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(116, 184, 139, 0.4)
+  app-header-background-color: rgba(114, 188, 139, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -1112,7 +1112,7 @@ ios-light-mode-orange-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(254, 190, 86, 0.4)
+  app-header-background-color: rgba(255, 229, 116, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -1199,7 +1199,7 @@ ios-light-mode-orange:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(254, 190, 86, 0.4)
+  app-header-background-color: rgba(255, 229, 116, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -1286,7 +1286,7 @@ ios-dark-mode-orange-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(254, 190, 86, 0.4)
+  app-header-background-color: rgba(255, 229, 116, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -1373,7 +1373,7 @@ ios-dark-mode-orange:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(254, 190, 86, 0.4)
+  app-header-background-color: rgba(255, 229, 116, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -1460,7 +1460,7 @@ ios-light-mode-blue-red-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(63, 36, 75, 0.4)
+  app-header-background-color: rgba(30, 2, 61, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -1547,7 +1547,7 @@ ios-light-mode-blue-red:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(63, 36, 75, 0.4)
+  app-header-background-color: rgba(30, 2, 61, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -1634,7 +1634,7 @@ ios-dark-mode-blue-red-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(63, 36, 75, 0.4)
+  app-header-background-color: rgba(30, 2, 61, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -1721,7 +1721,7 @@ ios-dark-mode-blue-red:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(63, 36, 75, 0.4)
+  app-header-background-color: rgba(30, 2, 61, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -1808,7 +1808,7 @@ ios-light-mode-red-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(249, 129, 97, 0.4)
+  app-header-background-color: rgba(234, 88, 63, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -1895,7 +1895,7 @@ ios-light-mode-red:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(249, 129, 97, 0.4)
+  app-header-background-color: rgba(234, 88, 63, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -1982,7 +1982,7 @@ ios-dark-mode-red-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(249, 129, 97, 0.4)
+  app-header-background-color: rgba(234, 88, 63, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -2069,7 +2069,7 @@ ios-dark-mode-red:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(249, 129, 97, 0.4)
+  app-header-background-color: rgba(234, 88, 63, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -2156,7 +2156,7 @@ ios-light-mode-dark-blue-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(118, 129, 167, 0.4)
+  app-header-background-color: rgba(48, 69, 124, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -2243,7 +2243,7 @@ ios-light-mode-dark-blue:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(118, 129, 167, 0.4)
+  app-header-background-color: rgba(48, 69, 124, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -2330,7 +2330,7 @@ ios-dark-mode-dark-blue-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(118, 129, 167, 0.4)
+  app-header-background-color: rgba(48, 69, 124, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -2417,7 +2417,7 @@ ios-dark-mode-dark-blue:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(118, 129, 167, 0.4)
+  app-header-background-color: rgba(48, 69, 124, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom

--- a/themes/ios-themes.yaml
+++ b/themes/ios-themes.yaml
@@ -68,7 +68,7 @@ ios-light-mode-dark-green-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(61, 107, 86, 0.4)
+  app-header-background-color: rgba(48, 89, 71, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -155,7 +155,7 @@ ios-light-mode-dark-green:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(61, 107, 86, 0.4)
+  app-header-background-color: rgba(48, 89, 71, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -242,7 +242,7 @@ ios-dark-mode-dark-green-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(61, 107, 86, 0.4)
+  app-header-background-color: rgba(48, 89, 71, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -329,7 +329,7 @@ ios-dark-mode-dark-green:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(61, 107, 86, 0.4)
+  app-header-background-color: rgba(48, 89, 71, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -416,7 +416,7 @@ ios-light-mode-light-blue-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(1, 133, 162, 0.4)
+  app-header-background-color: rgba(1, 195, 220, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -503,7 +503,7 @@ ios-light-mode-light-blue:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(1, 133, 162, 0.4)
+  app-header-background-color: rgba(1, 195, 220, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -590,7 +590,7 @@ ios-dark-mode-light-blue-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(1, 133, 162, 0.4)
+  app-header-background-color: rgba(1, 195, 220, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -677,7 +677,7 @@ ios-dark-mode-light-blue:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(1, 133, 162, 0.4)
+  app-header-background-color: rgba(1, 195, 220, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -764,7 +764,7 @@ ios-light-mode-light-green-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(116, 184, 139, 0.4)
+  app-header-background-color: rgba(114, 188, 139, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -851,7 +851,7 @@ ios-light-mode-light-green:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(116, 184, 139, 0.4)
+  app-header-background-color: rgba(114, 188, 139, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -938,7 +938,7 @@ ios-dark-mode-light-green-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(116, 184, 139, 0.4)
+  app-header-background-color: rgba(114, 188, 139, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -1025,7 +1025,7 @@ ios-dark-mode-light-green:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(116, 184, 139, 0.4)
+  app-header-background-color: rgba(114, 188, 139, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -1112,7 +1112,7 @@ ios-light-mode-orange-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(254, 190, 86, 0.4)
+  app-header-background-color: rgba(255, 229, 116, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -1199,7 +1199,7 @@ ios-light-mode-orange:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(254, 190, 86, 0.4)
+  app-header-background-color: rgba(255, 229, 116, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -1286,7 +1286,7 @@ ios-dark-mode-orange-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(254, 190, 86, 0.4)
+  app-header-background-color: rgba(255, 229, 116, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -1373,7 +1373,7 @@ ios-dark-mode-orange:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(254, 190, 86, 0.4)
+  app-header-background-color: rgba(255, 229, 116, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -1460,7 +1460,7 @@ ios-light-mode-blue-red-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(63, 36, 75, 0.4)
+  app-header-background-color: rgba(30, 2, 61, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -1547,7 +1547,7 @@ ios-light-mode-blue-red:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(63, 36, 75, 0.4)
+  app-header-background-color: rgba(30, 2, 61, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -1634,7 +1634,7 @@ ios-dark-mode-blue-red-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(63, 36, 75, 0.4)
+  app-header-background-color: rgba(30, 2, 61, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -1721,7 +1721,7 @@ ios-dark-mode-blue-red:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(63, 36, 75, 0.4)
+  app-header-background-color: rgba(30, 2, 61, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -1808,7 +1808,7 @@ ios-light-mode-red-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(249, 129, 97, 0.4)
+  app-header-background-color: rgba(234, 88, 63, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -1895,7 +1895,7 @@ ios-light-mode-red:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(249, 129, 97, 0.4)
+  app-header-background-color: rgba(234, 88, 63, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -1982,7 +1982,7 @@ ios-dark-mode-red-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(249, 129, 97, 0.4)
+  app-header-background-color: rgba(234, 88, 63, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -2069,7 +2069,7 @@ ios-dark-mode-red:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(249, 129, 97, 0.4)
+  app-header-background-color: rgba(234, 88, 63, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -2156,7 +2156,7 @@ ios-light-mode-dark-blue-alternative:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(118, 129, 167, 0.4)
+  app-header-background-color: rgba(48, 69, 124, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -2243,7 +2243,7 @@ ios-light-mode-dark-blue:
   paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(118, 129, 167, 0.4)
+  app-header-background-color: rgba(48, 69, 124, 0.4)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   # Custom
@@ -2330,7 +2330,7 @@ ios-dark-mode-dark-blue-alternative:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(118, 129, 167, 0.4)
+  app-header-background-color: rgba(48, 69, 124, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom
@@ -2417,7 +2417,7 @@ ios-dark-mode-dark-blue:
   paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(118, 129, 167, 0.4)
+  app-header-background-color: rgba(48, 69, 124, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   # Custom


### PR DESCRIPTION
Add hard-coded header colors suggested by @okets in #42

I added 0.4 transparency to the colors suggested in https://github.com/basnijholt/lovelace-ios-themes/issues/42#issuecomment-1321111701.