### PR TITLE
Add rgb-card-background-color to fix QR codes

### DIFF
--- a/manual-install/ios-themes.yaml
+++ b/manual-install/ios-themes.yaml
@@ -1,6 +1,710 @@
 ---
 # From https://github.com/basnijholt/lovelace-ios-themes
 #
+# iOS Light Mode Theme - blue-red
+#
+ios-light-mode-blue-red-alternative:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-blue-red.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9409"  # from Apple systemOrange light mode
+  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#e5e5ea"  # systemGray5 light mode
+  secondary-background-color: rgba(255, 255, 255, 0.9)
+  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#464a47"
+  secondary-text-color: "#000000"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: var(--light-primary-color)
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(245, 245, 245, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(230, 230, 230, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(30, 2, 61, 0.4)
+  markdown-code-background-color: "#FFFFFF"
+  code-editor-background-color: "#FFF"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Light Mode Theme - blue-red
+#
+ios-light-mode-blue-red:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-blue-red.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9409"  # from Apple systemOrange light mode
+  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#e5e5ea"  # systemGray5 light mode
+  secondary-background-color: rgba(255, 255, 255, 0.9)
+  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#464a47"
+  secondary-text-color: "#000000"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: var(--light-primary-color)
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(245, 245, 245, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(230, 230, 230, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(30, 2, 61, 0.4)
+  markdown-code-background-color: "#FFFFFF"
+  code-editor-background-color: "#FFF"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Dark Mode Theme - blue-red
+#
+ios-dark-mode-blue-red-alternative:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-blue-red.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
+  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
+  secondary-background-color: rgba(25, 25, 25, 0.9)
+  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#FFF"
+  secondary-text-color: "#d3d3d3"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: "#F1F1F1"
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(10, 10, 10, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(25, 25, 25, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(30, 2, 61, 0.4)
+  markdown-code-background-color: "#464646"
+  code-editor-background-color: "#161616"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Dark Mode Theme - blue-red
+#
+ios-dark-mode-blue-red:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-blue-red.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
+  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
+  secondary-background-color: rgba(25, 25, 25, 0.9)
+  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#FFF"
+  secondary-text-color: "#d3d3d3"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: "#F1F1F1"
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(10, 10, 10, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(25, 25, 25, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(30, 2, 61, 0.4)
+  markdown-code-background-color: "#464646"
+  code-editor-background-color: "#161616"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Light Mode Theme - dark-blue
+#
+ios-light-mode-dark-blue-alternative:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-dark-blue.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9409"  # from Apple systemOrange light mode
+  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#e5e5ea"  # systemGray5 light mode
+  secondary-background-color: rgba(255, 255, 255, 0.9)
+  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#464a47"
+  secondary-text-color: "#000000"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: var(--light-primary-color)
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(245, 245, 245, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(230, 230, 230, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(48, 69, 124, 0.4)
+  markdown-code-background-color: "#FFFFFF"
+  code-editor-background-color: "#FFF"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Light Mode Theme - dark-blue
+#
+ios-light-mode-dark-blue:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-dark-blue.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9409"  # from Apple systemOrange light mode
+  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#e5e5ea"  # systemGray5 light mode
+  secondary-background-color: rgba(255, 255, 255, 0.9)
+  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#464a47"
+  secondary-text-color: "#000000"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: var(--light-primary-color)
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(245, 245, 245, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(230, 230, 230, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(48, 69, 124, 0.4)
+  markdown-code-background-color: "#FFFFFF"
+  code-editor-background-color: "#FFF"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Dark Mode Theme - dark-blue
+#
+ios-dark-mode-dark-blue-alternative:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-dark-blue.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
+  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
+  secondary-background-color: rgba(25, 25, 25, 0.9)
+  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#FFF"
+  secondary-text-color: "#d3d3d3"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: "#F1F1F1"
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(10, 10, 10, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(25, 25, 25, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(48, 69, 124, 0.4)
+  markdown-code-background-color: "#464646"
+  code-editor-background-color: "#161616"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Dark Mode Theme - dark-blue
+#
+ios-dark-mode-dark-blue:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-dark-blue.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
+  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
+  secondary-background-color: rgba(25, 25, 25, 0.9)
+  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#FFF"
+  secondary-text-color: "#d3d3d3"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: "#F1F1F1"
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(10, 10, 10, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(25, 25, 25, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(48, 69, 124, 0.4)
+  markdown-code-background-color: "#464646"
+  code-editor-background-color: "#161616"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
 # iOS Light Mode Theme - dark-green
 #
 ios-light-mode-dark-green-alternative:
@@ -1409,358 +2113,6 @@ ios-dark-mode-orange:
   codemirror-property: var(--accent-color)
 
 #
-# iOS Light Mode Theme - blue-red
-#
-ios-light-mode-blue-red-alternative:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-blue-red.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9409"  # from Apple systemOrange light mode
-  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#e5e5ea"  # systemGray5 light mode
-  secondary-background-color: rgba(255, 255, 255, 0.9)
-  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#464a47"
-  secondary-text-color: "#000000"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: var(--light-primary-color)
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(230, 230, 230, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(30, 2, 61, 0.4)
-  markdown-code-background-color: "#FFFFFF"
-  code-editor-background-color: "#FFF"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Light Mode Theme - blue-red
-#
-ios-light-mode-blue-red:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-blue-red.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9409"  # from Apple systemOrange light mode
-  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#e5e5ea"  # systemGray5 light mode
-  secondary-background-color: rgba(255, 255, 255, 0.9)
-  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#464a47"
-  secondary-text-color: "#000000"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: var(--light-primary-color)
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(230, 230, 230, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(30, 2, 61, 0.4)
-  markdown-code-background-color: "#FFFFFF"
-  code-editor-background-color: "#FFF"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Dark Mode Theme - blue-red
-#
-ios-dark-mode-blue-red-alternative:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-blue-red.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
-  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
-  secondary-background-color: rgba(25, 25, 25, 0.9)
-  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#FFF"
-  secondary-text-color: "#d3d3d3"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: "#F1F1F1"
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(25, 25, 25, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(30, 2, 61, 0.4)
-  markdown-code-background-color: "#464646"
-  code-editor-background-color: "#161616"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Dark Mode Theme - blue-red
-#
-ios-dark-mode-blue-red:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-blue-red.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
-  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
-  secondary-background-color: rgba(25, 25, 25, 0.9)
-  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#FFF"
-  secondary-text-color: "#d3d3d3"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: "#F1F1F1"
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(25, 25, 25, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(30, 2, 61, 0.4)
-  markdown-code-background-color: "#464646"
-  code-editor-background-color: "#161616"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
 # iOS Light Mode Theme - red
 #
 ios-light-mode-red-alternative:
@@ -2093,358 +2445,6 @@ ios-dark-mode-red:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(234, 88, 63, 0.4)
-  markdown-code-background-color: "#464646"
-  code-editor-background-color: "#161616"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Light Mode Theme - dark-blue
-#
-ios-light-mode-dark-blue-alternative:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-dark-blue.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9409"  # from Apple systemOrange light mode
-  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#e5e5ea"  # systemGray5 light mode
-  secondary-background-color: rgba(255, 255, 255, 0.9)
-  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#464a47"
-  secondary-text-color: "#000000"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: var(--light-primary-color)
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(230, 230, 230, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(48, 69, 124, 0.4)
-  markdown-code-background-color: "#FFFFFF"
-  code-editor-background-color: "#FFF"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Light Mode Theme - dark-blue
-#
-ios-light-mode-dark-blue:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-dark-blue.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9409"  # from Apple systemOrange light mode
-  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#e5e5ea"  # systemGray5 light mode
-  secondary-background-color: rgba(255, 255, 255, 0.9)
-  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#464a47"
-  secondary-text-color: "#000000"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: var(--light-primary-color)
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(230, 230, 230, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(48, 69, 124, 0.4)
-  markdown-code-background-color: "#FFFFFF"
-  code-editor-background-color: "#FFF"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Dark Mode Theme - dark-blue
-#
-ios-dark-mode-dark-blue-alternative:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-dark-blue.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
-  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
-  secondary-background-color: rgba(25, 25, 25, 0.9)
-  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#FFF"
-  secondary-text-color: "#d3d3d3"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: "#F1F1F1"
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(25, 25, 25, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(48, 69, 124, 0.4)
-  markdown-code-background-color: "#464646"
-  code-editor-background-color: "#161616"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Dark Mode Theme - dark-blue
-#
-ios-dark-mode-dark-blue:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/local/themes/ios-themes/homekit-bg-dark-blue.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
-  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
-  secondary-background-color: rgba(25, 25, 25, 0.9)
-  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#FFF"
-  secondary-text-color: "#d3d3d3"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: "#F1F1F1"
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(25, 25, 25, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(48, 69, 124, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64

--- a/manual-install/ios-themes.yaml
+++ b/manual-install/ios-themes.yaml
@@ -50,6 +50,7 @@ ios-light-mode-blue-red-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -138,6 +139,7 @@ ios-light-mode-blue-red:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -226,6 +228,7 @@ ios-dark-mode-blue-red-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -314,6 +317,7 @@ ios-dark-mode-blue-red:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -402,6 +406,7 @@ ios-light-mode-dark-blue-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -490,6 +495,7 @@ ios-light-mode-dark-blue:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -578,6 +584,7 @@ ios-dark-mode-dark-blue-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -666,6 +673,7 @@ ios-dark-mode-dark-blue:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -754,6 +762,7 @@ ios-light-mode-dark-green-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -842,6 +851,7 @@ ios-light-mode-dark-green:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -930,6 +940,7 @@ ios-dark-mode-dark-green-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1018,6 +1029,7 @@ ios-dark-mode-dark-green:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1106,6 +1118,7 @@ ios-light-mode-light-blue-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1194,6 +1207,7 @@ ios-light-mode-light-blue:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1282,6 +1296,7 @@ ios-dark-mode-light-blue-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1370,6 +1385,7 @@ ios-dark-mode-light-blue:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1458,6 +1474,7 @@ ios-light-mode-light-green-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1546,6 +1563,7 @@ ios-light-mode-light-green:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1634,6 +1652,7 @@ ios-dark-mode-light-green-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1722,6 +1741,7 @@ ios-dark-mode-light-green:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1810,6 +1830,7 @@ ios-light-mode-orange-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1898,6 +1919,7 @@ ios-light-mode-orange:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1986,6 +2008,7 @@ ios-dark-mode-orange-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -2074,6 +2097,7 @@ ios-dark-mode-orange:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -2162,6 +2186,7 @@ ios-light-mode-red-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -2250,6 +2275,7 @@ ios-light-mode-red:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -2338,6 +2364,7 @@ ios-dark-mode-red-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -2426,6 +2453,7 @@ ios-dark-mode-red:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"

--- a/settings-light-dark.yaml
+++ b/settings-light-dark.yaml
@@ -4,6 +4,9 @@ divider_color:
 ha_card_background:
   dark: rgba(10, 10, 10, 0.4)
   light: rgba(245, 245, 245, 0.4)
+rgb_card_background:
+  dark: rgb(10, 10, 10)
+  light: rgb(245, 245, 245)
 label_badge_red:
   dark: rgba(255, 159, 9, 0.7)
   light: rgba(255, 149, 9, 0.7)

--- a/template.jinja2
+++ b/template.jinja2
@@ -48,6 +48,7 @@ ios-{{ which }}-mode-{{ color }}{{ suffix }}:
   ha-card-border-radius: 20px
   ha-card-background: {{  ha_card_background }}
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: {{ rgb_card_background }} # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"

--- a/themes/ios-themes.yaml
+++ b/themes/ios-themes.yaml
@@ -1,6 +1,710 @@
 ---
 # From https://github.com/basnijholt/lovelace-ios-themes
 #
+# iOS Light Mode Theme - blue-red
+#
+ios-light-mode-blue-red-alternative:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-blue-red.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9409"  # from Apple systemOrange light mode
+  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#e5e5ea"  # systemGray5 light mode
+  secondary-background-color: rgba(255, 255, 255, 0.9)
+  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#464a47"
+  secondary-text-color: "#000000"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: var(--light-primary-color)
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(245, 245, 245, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(230, 230, 230, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(30, 2, 61, 0.4)
+  markdown-code-background-color: "#FFFFFF"
+  code-editor-background-color: "#FFF"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Light Mode Theme - blue-red
+#
+ios-light-mode-blue-red:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-blue-red.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9409"  # from Apple systemOrange light mode
+  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#e5e5ea"  # systemGray5 light mode
+  secondary-background-color: rgba(255, 255, 255, 0.9)
+  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#464a47"
+  secondary-text-color: "#000000"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: var(--light-primary-color)
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(245, 245, 245, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(230, 230, 230, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(30, 2, 61, 0.4)
+  markdown-code-background-color: "#FFFFFF"
+  code-editor-background-color: "#FFF"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Dark Mode Theme - blue-red
+#
+ios-dark-mode-blue-red-alternative:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-blue-red.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
+  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
+  secondary-background-color: rgba(25, 25, 25, 0.9)
+  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#FFF"
+  secondary-text-color: "#d3d3d3"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: "#F1F1F1"
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(10, 10, 10, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(25, 25, 25, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(30, 2, 61, 0.4)
+  markdown-code-background-color: "#464646"
+  code-editor-background-color: "#161616"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Dark Mode Theme - blue-red
+#
+ios-dark-mode-blue-red:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-blue-red.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
+  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
+  secondary-background-color: rgba(25, 25, 25, 0.9)
+  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#FFF"
+  secondary-text-color: "#d3d3d3"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: "#F1F1F1"
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(10, 10, 10, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(25, 25, 25, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(30, 2, 61, 0.4)
+  markdown-code-background-color: "#464646"
+  code-editor-background-color: "#161616"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Light Mode Theme - dark-blue
+#
+ios-light-mode-dark-blue-alternative:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-dark-blue.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9409"  # from Apple systemOrange light mode
+  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#e5e5ea"  # systemGray5 light mode
+  secondary-background-color: rgba(255, 255, 255, 0.9)
+  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#464a47"
+  secondary-text-color: "#000000"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: var(--light-primary-color)
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(245, 245, 245, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(230, 230, 230, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(48, 69, 124, 0.4)
+  markdown-code-background-color: "#FFFFFF"
+  code-editor-background-color: "#FFF"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Light Mode Theme - dark-blue
+#
+ios-light-mode-dark-blue:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-dark-blue.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9409"  # from Apple systemOrange light mode
+  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#e5e5ea"  # systemGray5 light mode
+  secondary-background-color: rgba(255, 255, 255, 0.9)
+  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#464a47"
+  secondary-text-color: "#000000"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: var(--light-primary-color)
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(245, 245, 245, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(230, 230, 230, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(48, 69, 124, 0.4)
+  markdown-code-background-color: "#FFFFFF"
+  code-editor-background-color: "#FFF"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Dark Mode Theme - dark-blue
+#
+ios-dark-mode-dark-blue-alternative:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-dark-blue.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
+  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
+  secondary-background-color: rgba(25, 25, 25, 0.9)
+  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#FFF"
+  secondary-text-color: "#d3d3d3"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: "#F1F1F1"
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(10, 10, 10, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(25, 25, 25, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(48, 69, 124, 0.4)
+  markdown-code-background-color: "#464646"
+  code-editor-background-color: "#161616"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
+# iOS Dark Mode Theme - dark-blue
+#
+ios-dark-mode-dark-blue:
+  # Global
+  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-dark-blue.jpg')"
+  lovelace-background: var(--background-image)
+  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
+  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
+  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
+  secondary-background-color: rgba(25, 25, 25, 0.9)
+  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
+  accent-color: rgba(255, 159, 9, 1)
+  # Text
+  primary-text-color: "#FFF"
+  secondary-text-color: "#d3d3d3"
+  text-primary-color: "#FFF"
+  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
+  text-dark-color: "#FFF"
+  # Sidebar Menu
+  sidebar-background-color: var(--primary-background-color)
+  sidebar-icon-color: var(--light-primary-color)
+  sidebar-text-color: "#F1F1F1"
+  sidebar-selected-background-color: var(--primary-background-color)
+  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
+  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
+  # States and Badges
+  state-icon-color: "#FFF"
+  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
+  state-icon-unavailable-color: var(--disabled-text-color)
+  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
+  # Sliders
+  paper-slider-knob-color: "#FFFFFF"
+  paper-slider-knob-start-color: var(--paper-slider-knob-color)
+  paper-slider-pin-color: var(--paper-slider-knob-color)
+  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
+  paper-slider-secondary-color: var(--paper-slider-knob-color)
+  paper-slider-container-color: rgba(255, 255, 255, 0.5)
+  paper-slider-font-color: "#000"
+  ha-slider-background: none !important
+  # Labels
+  label-badge-background-color: "#23232E"
+  label-badge-text-color: "#F1F1F1"
+  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
+  # Cards
+  card-background-color: var(--secondary-background-color)  # Unused entities table background
+  paper-listbox-background-color: var(--primary-background-color)
+  ha-card-border-radius: 20px
+  ha-card-background: rgba(10, 10, 10, 0.4)
+  paper-card-background-color: var(--ha-card-background)
+  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
+  # Toggles
+  paper-toggle-button-checked-button-color: "#484848"
+  paper-toggle-button-checked-bar-color: "#484848"
+  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
+  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
+  # Table row
+  table-row-background-color: var(--primary-background-color)
+  table-row-alternative-background-color: var(--secondary-background-color)
+  # Switches
+  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
+  switch-checked-button-color: "#FFF"
+  # Other
+  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
+  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  more-info-header-background: rgba(25, 25, 25, 0.5)
+  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
+  app-header-background-color: rgba(48, 69, 124, 0.4)
+  markdown-code-background-color: "#464646"
+  code-editor-background-color: "#161616"
+  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
+  # Custom
+  mcg-title-letter-spacing: .15em
+  mini-media-player-base-color: white
+  mini-media-player-icon-color: white
+  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
+  input-ink-color: var(--primary-text-color)
+  input-fill-color: transparent
+  input-disabled-fill-color: transparent
+  input-label-ink-color: var(--primary-text-color)
+  input-disabled-ink-color: var(--disabled-text-color)
+  input-dropdown-icon-color: var(--primary-text-color)
+  input-idle-line-color: var(--secondary-text-color)
+  input-hover-line-color: var(--secondary-text-color)
+  codemirror-property: var(--accent-color)
+
+#
 # iOS Light Mode Theme - dark-green
 #
 ios-light-mode-dark-green-alternative:
@@ -1409,358 +2113,6 @@ ios-dark-mode-orange:
   codemirror-property: var(--accent-color)
 
 #
-# iOS Light Mode Theme - blue-red
-#
-ios-light-mode-blue-red-alternative:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-blue-red.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9409"  # from Apple systemOrange light mode
-  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#e5e5ea"  # systemGray5 light mode
-  secondary-background-color: rgba(255, 255, 255, 0.9)
-  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#464a47"
-  secondary-text-color: "#000000"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: var(--light-primary-color)
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(230, 230, 230, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(30, 2, 61, 0.4)
-  markdown-code-background-color: "#FFFFFF"
-  code-editor-background-color: "#FFF"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Light Mode Theme - blue-red
-#
-ios-light-mode-blue-red:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-blue-red.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9409"  # from Apple systemOrange light mode
-  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#e5e5ea"  # systemGray5 light mode
-  secondary-background-color: rgba(255, 255, 255, 0.9)
-  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#464a47"
-  secondary-text-color: "#000000"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: var(--light-primary-color)
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(230, 230, 230, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(30, 2, 61, 0.4)
-  markdown-code-background-color: "#FFFFFF"
-  code-editor-background-color: "#FFF"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Dark Mode Theme - blue-red
-#
-ios-dark-mode-blue-red-alternative:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-blue-red.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
-  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
-  secondary-background-color: rgba(25, 25, 25, 0.9)
-  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#FFF"
-  secondary-text-color: "#d3d3d3"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: "#F1F1F1"
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(25, 25, 25, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(30, 2, 61, 0.4)
-  markdown-code-background-color: "#464646"
-  code-editor-background-color: "#161616"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Dark Mode Theme - blue-red
-#
-ios-dark-mode-blue-red:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-blue-red.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
-  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
-  secondary-background-color: rgba(25, 25, 25, 0.9)
-  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#FFF"
-  secondary-text-color: "#d3d3d3"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: "#F1F1F1"
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(25, 25, 25, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(30, 2, 61, 0.4)
-  markdown-code-background-color: "#464646"
-  code-editor-background-color: "#161616"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
 # iOS Light Mode Theme - red
 #
 ios-light-mode-red-alternative:
@@ -2093,358 +2445,6 @@ ios-dark-mode-red:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(234, 88, 63, 0.4)
-  markdown-code-background-color: "#464646"
-  code-editor-background-color: "#161616"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Light Mode Theme - dark-blue
-#
-ios-light-mode-dark-blue-alternative:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-dark-blue.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9409"  # from Apple systemOrange light mode
-  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#e5e5ea"  # systemGray5 light mode
-  secondary-background-color: rgba(255, 255, 255, 0.9)
-  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#464a47"
-  secondary-text-color: "#000000"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: var(--light-primary-color)
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(230, 230, 230, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(48, 69, 124, 0.4)
-  markdown-code-background-color: "#FFFFFF"
-  code-editor-background-color: "#FFF"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Light Mode Theme - dark-blue
-#
-ios-light-mode-dark-blue:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-dark-blue.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9409"  # from Apple systemOrange light mode
-  light-primary-color: "#2c2c2e"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#e5e5ea"  # systemGray5 light mode
-  secondary-background-color: rgba(255, 255, 255, 0.9)
-  divider-color: rgba(142, 142, 147, 0.3)  # from Apple systemGray light mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#464a47"
-  secondary-text-color: "#000000"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: var(--light-primary-color)
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#8e8e93"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(230, 230, 230, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(48, 69, 124, 0.4)
-  markdown-code-background-color: "#FFFFFF"
-  code-editor-background-color: "#FFF"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Dark Mode Theme - dark-blue
-#
-ios-dark-mode-dark-blue-alternative:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-dark-blue.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
-  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
-  secondary-background-color: rgba(25, 25, 25, 0.9)
-  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#FFF"
-  secondary-text-color: "#d3d3d3"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: "#F1F1F1"
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(25, 25, 25, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(48, 69, 124, 0.4)
-  markdown-code-background-color: "#464646"
-  code-editor-background-color: "#161616"
-  clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
-  # Custom
-  mcg-title-letter-spacing: .15em
-  mini-media-player-base-color: white
-  mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
-  codemirror-property: var(--accent-color)
-
-#
-# iOS Dark Mode Theme - dark-blue
-#
-ios-dark-mode-dark-blue:
-  # Global
-  background-image: "center / cover no-repeat fixed url('/hacsfiles/themes/ios-themes/homekit-bg-dark-blue.jpg')"
-  lovelace-background: var(--background-image)
-  primary-color: "#ff9f09"  # from Apple systemOrange dark mode
-  light-primary-color: "#B6B6C1"  # (icons on left menu) (light: systemGray5 from iOS dark mode, dark: XXX)
-  primary-background-color: "#2c2c2e"  # systemGray5 dark mode
-  secondary-background-color: rgba(25, 25, 25, 0.9)
-  divider-color: rgba(152, 152, 157, 0.3)  # from Apple systemGray dark mode
-  accent-color: rgba(255, 159, 9, 1)
-  # Text
-  primary-text-color: "#FFF"
-  secondary-text-color: "#d3d3d3"
-  text-primary-color: "#FFF"
-  disabled-text-color: "#555"  # XXX: https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/2
-  text-dark-color: "#FFF"
-  # Sidebar Menu
-  sidebar-background-color: var(--primary-background-color)
-  sidebar-icon-color: var(--light-primary-color)
-  sidebar-text-color: "#F1F1F1"
-  sidebar-selected-background-color: var(--primary-background-color)
-  sidebar-selected-icon-color: "#FFF"  # (light: systemGray5 from iOS light mode, dark: XXX)
-  sidebar-selected-text-color: var(--sidebar-selected-icon-color)
-  # States and Badges
-  state-icon-color: "#FFF"
-  state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
-  state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
-  ha-slider-background: none !important
-  # Labels
-  label-badge-background-color: "#23232E"
-  label-badge-text-color: "#F1F1F1"
-  label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
-  # Cards
-  card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
-  ha-card-border-radius: 20px
-  ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
-  ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
-  # Table row
-  table-row-background-color: var(--primary-background-color)
-  table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
-  switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
-  switch-checked-button-color: "#FFF"
-  # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
-  more-info-header-background: rgba(25, 25, 25, 0.5)
-  lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
-  app-header-background-color: rgba(48, 69, 124, 0.4)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64

--- a/themes/ios-themes.yaml
+++ b/themes/ios-themes.yaml
@@ -50,6 +50,7 @@ ios-light-mode-blue-red-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -138,6 +139,7 @@ ios-light-mode-blue-red:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -226,6 +228,7 @@ ios-dark-mode-blue-red-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -314,6 +317,7 @@ ios-dark-mode-blue-red:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -402,6 +406,7 @@ ios-light-mode-dark-blue-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -490,6 +495,7 @@ ios-light-mode-dark-blue:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -578,6 +584,7 @@ ios-dark-mode-dark-blue-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -666,6 +673,7 @@ ios-dark-mode-dark-blue:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -754,6 +762,7 @@ ios-light-mode-dark-green-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -842,6 +851,7 @@ ios-light-mode-dark-green:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -930,6 +940,7 @@ ios-dark-mode-dark-green-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1018,6 +1029,7 @@ ios-dark-mode-dark-green:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1106,6 +1118,7 @@ ios-light-mode-light-blue-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1194,6 +1207,7 @@ ios-light-mode-light-blue:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1282,6 +1296,7 @@ ios-dark-mode-light-blue-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1370,6 +1385,7 @@ ios-dark-mode-light-blue:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1458,6 +1474,7 @@ ios-light-mode-light-green-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1546,6 +1563,7 @@ ios-light-mode-light-green:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1634,6 +1652,7 @@ ios-dark-mode-light-green-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1722,6 +1741,7 @@ ios-dark-mode-light-green:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1810,6 +1830,7 @@ ios-light-mode-orange-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1898,6 +1919,7 @@ ios-light-mode-orange:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -1986,6 +2008,7 @@ ios-dark-mode-orange-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -2074,6 +2097,7 @@ ios-dark-mode-orange:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -2162,6 +2186,7 @@ ios-light-mode-red-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -2250,6 +2275,7 @@ ios-light-mode-red:
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -2338,6 +2364,7 @@ ios-dark-mode-red-alternative:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"
@@ -2426,6 +2453,7 @@ ios-dark-mode-red:
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
   paper-card-background-color: var(--ha-card-background)
+  rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
   # Toggles
   paper-toggle-button-checked-button-color: "#484848"


### PR DESCRIPTION
Add rgb-card-background-color to fix QR codes. It seems that this variable was meant to be the same as the card background color, but without the alpha component. I'm not sure why this variable is used to generate QR codes instead of hardcoded #000 and #fff, but I guess the idea behind doing that in https://github.com/home-assistant/frontend/pull/19726 was dark mode support.

Resolves #60 and the issue mentioned in https://github.com/basnijholt/lovelace-ios-themes/issues/64#issuecomment-2040681203

Note: I regenerated the themes in commit https://github.com/basnijholt/lovelace-ios-themes/commit/a8691373a58697653e215f227d7e7580c5ca0b1f. Maybe it's due to using a different OS, but this line
```
for background in Path("themes").glob("homekit-bg-*.jpg"):
```
returns the images in alphabetical order for me, whereas they were in a seemingly random order previously.

Commit https://github.com/basnijholt/lovelace-ios-themes/commit/19f550bec6cec839a4a427aea96f3a220d1f59c9 contains the clean diff of the theme files.