### PR TITLE
2026.3.x refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,97 +26,6 @@ Installing this theme adds 28 different themes:
 - `ios-dark-mode-dark-blue`
 - `...` and versions with the `-alternative` suffix
 
----
-
-## **🖼️ Backgrounds: Remote vs Local**
-
-As of version **3.0.0**, we have introduced an alternative to Base64-encoded background images to boost performance.
-
-By default, iOS Themes now use **remote background images** hosted on GitHub for faster caching and loading times. However, for users that prefer to host images locally on their Home Assistant setup (or in environments with poor internet connectivity), `-alternative` versions of the themes are available, which use locally hosted background images.
-
-### **Remote Backgrounds (Default)**
-
-- The default themes use background images stored in our GitHub repository.
-- To switch to the default themes, no configuration beyond the installation steps is necessary.
-
-### **Local Backgrounds (Alternative Versions)**
-
-For the alternative themes, you will need to **download the images and store them locally** in your Home Assistant's `/config/www/ios-themes` directory. Home Assistant automatically serves files from the `www` folder under `/local/`.
-
----
-
-<details>
-<summary>📥 How to Download Backgrounds for Local Use (Alternative Themes)</summary>
-
-### **Step-by-Step Local Background Setup**:
-
-To use locally hosted background images, follow the instructions below.
-
-1. **Create the necessary directory**:
-   Open a terminal (or SSH into your Home Assistant setup) and run the following command to ensure the correct folder structure is in place:
-   ```bash
-   mkdir -p /config/www/ios-themes
-   ```
-
-2. **Download the background images**:
-   Download the required background images using `wget` commands. This will store them in the `/config/www/ios-themes` folder.
-   
-   For example:
-   ```bash
-   # Dark Blue background
-   wget -O /config/www/ios-themes/homekit-bg-dark-blue.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-dark-blue.jpg
-   
-   # Light Blue background
-   wget -O /config/www/ios-themes/homekit-bg-dark-blue.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-light-blue.jpg
-   
-   # Add more backgrounds as needed for other themes
-   ```
-
-   Repeat the command for all the backgrounds you need (ensure to replace `dark-blue.jpg` with the appropriate background name from the themes you're using).
-
-3. **Switch to the alternative theme**:
-   In your Home Assistant profile settings, select the **alternative version** of the theme you want to use.  
-   Example: `ios-dark-mode-dark-blue-alternative`
-
-   **Important:** For images hosted locally, the background paths in the theme are referenced as `/local/ios-themes/...`.
-
----
-
-### **Command Summary for Downloading Backgrounds**:
-
-Here are commands to download all available backgrounds:
-
-```bash
-# Dark Blue
-wget -O /config/www/ios-themes/homekit-bg-dark-blue.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-dark-blue.jpg
-
-# Light Blue
-wget -O /config/www/ios-themes/homekit-bg-light-blue.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-light-blue.jpg
-
-# Dark Green
-wget -O /config/www/ios-themes/homekit-bg-dark-green.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-dark-green.jpg
-
-# Light Green
-wget -O /config/www/ios-themes/homekit-bg-light-green.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-light-green.jpg
-
-# Orange
-wget -O /config/www/ios-themes/homekit-bg-orange.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-orange.jpg
-
-# Blue Red
-wget -O /config/www/ios-themes/homekit-bg-blue-red.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-blue-red.jpg
-
-# Red
-wget -O /config/www/ios-themes/homekit-bg-red.jpg https://raw.githubusercontent.com/basnijholt/lovelace-ios-themes/master/themes/homekit-bg-red.jpg
-```
-
----
-
-After placing the images in the `/config/www/ios-themes/` directory, reload your Home Assistant theme settings (or restart Home Assistant) and enjoy using the responsive, locally hosted backgrounds!
-
-</details>
-
----
-
 ## Screenshots
 
 Screenshots of [my](https://github.com/basnijholt) Home-Assistant instance, [see the config files here :octocat:](https://github.com/basnijholt/home-assistant-config/).
@@ -145,14 +54,14 @@ Low quality `gif`, click [here](https://github.com/basnijholt/lovelace-ios-theme
 
 ## Installation
 
-1. Installation of the themes with HACS.
+1. Install the theme via HACS.
 
-* (If you do not have it yet) Install [HACS](https://hacs.xyz/docs/installation/manual).
-* Go to the HACS Community Store.
-* Click on the `THEMES` tab.
-* Search and install the `iOS Themes`.
+* If you do not have HACS yet, [download and set it up](https://www.hacs.xyz/docs/use/download/download/) first — a GitHub account is required.
+* In Home Assistant, open **HACS** from the sidebar.
+* Search for `iOS Themes` and select it.
+* In the bottom-right corner, select **Download**.
 
-2. Add the following code to your `configuration.yaml` file (reboot required).
+2. Add the following to your `configuration.yaml` (reboot required).
 
 ```yaml
 frontend:
@@ -161,7 +70,10 @@ frontend:
   ... # your configuration.
 ```
 
-3. Add the following line to your `lovelace-ui.yaml` or use the RAW editor:
+3. Set the background on your dashboard.
+
+Open your dashboard, select **Edit dashboard** (pencil icon) → **⋮ Open dashboard menu** → **Raw configuration editor**, and add this at the top level:
+
 ```yaml
 background: var(--background-image)
 ```
@@ -169,9 +81,10 @@ background: var(--background-image)
 So the end result will be something like [this example](https://github.com/basnijholt/home-assistant-config/blob/master/lovelace-ui.yaml).
 
 ## Automations to easily switch
-**WARNING: if you want to switch themes using automations, you need to go to your profile and select "Backend-selected" for Theme!**
 
-It is recommended to use [these automations (`basnijholt/home-assistant-config/automations/frontend.yaml`)](https://github.com/basnijholt/home-assistant-config/blob/master/automations/frontend.yaml) in combination with these:
+**Note:** To switch themes via automations or the UI helpers below, go to your profile (**Settings** → **[your name]**) and set **Theme** to **Backend-selected**.
+
+It is recommended to use [these automations (`basnijholt/home-assistant-config/automations/frontend.yaml`)](https://github.com/basnijholt/home-assistant-config/blob/master/automations/frontend.yaml) in combination with these helpers:
 ```yaml
 input_select:
   theme:
@@ -192,10 +105,32 @@ input_boolean:
   theme_alternative:
     name: Theme alternative (disable active state color)
 ```
-Then add `input_select.theme`, `input_boolean.theme_alternative`, and `input_boolean.dark_mode` to your Lovelace UI.
+
+You can define these helpers in `configuration.yaml` as shown above, or create them via **Settings** → **Devices & Services** → **Helpers**. Then add `input_select.theme`, `input_boolean.theme_alternative`, and `input_boolean.dark_mode` to your dashboard.
 
 
 ## How does the code work
 
 All the **28(!)** themes in [`themes/`](themes/) are **automatically generated** using [`create-themes.py`](create-themes.py) and the information in [`settings-light-dark.yaml`](settings-light-dark.yaml) is passed into [`template.jinja2`](template.jinja2).
 The resulting file is [`themes/ios-themes.yaml`](themes/ios-themes.yaml) which contains all variants (different backgrounds and dark/light mode).
+
+## HA 2025.5+ compatibility
+
+This theme has been modernized to remove deprecated variables and add support
+for UI components introduced in Home Assistant 2025.5.
+
+**Removed** (Polymer/`paper-*` components were removed in HA 2025.5):
+- `paper-slider-*` — sliders now follow `--primary-color` / `--accent-color` automatically
+- `paper-toggle-button-*` — switches use `switch-checked-*` variables
+- `paper-listbox-background-color`
+- `paper-card-background-color`
+- `paper-item-icon-color` / `paper-item-icon-active-color`
+- Vaadin `--vaadin-text-field-*` input variables
+
+**Updated:**
+- `paper-dialog-background-color` → `dialog-background-color`
+
+**Added** (view tab styling for `ha-tabs` / `sl-tab` in HA 2025.5+):
+- `app-header-selection-bar-color` — active view tab indicator bar colour
+- `sl-color-primary-600` — active view tab text/icon colour
+- `sl-color-neutral-600` — inactive view tab text/icon colour

--- a/settings-light-dark.yaml
+++ b/settings-light-dark.yaml
@@ -16,15 +16,9 @@ light_primary_color:
 more_info_header_background:
   dark: rgba(25, 25, 25, 0.5)
   light: rgba(230, 230, 230, 0.5)
-paper_dialog_background_color:
+dialog_background_color:
   dark: rgba(55, 55, 55, 0.8)
   light: rgba(200, 200, 200, 0.8)
-paper_item_icon_color:
-  dark: white
-  light: '#333333'
-paper_slider_active_color:
-  dark: '#0984ff'
-  light: '#007aff'
 primary_background_color:
   dark: '#2c2c2e'
   light: '#e5e5ea'

--- a/template.jinja2
+++ b/template.jinja2
@@ -28,15 +28,7 @@ ios-{{ which }}-mode-{{ color }}{{ suffix }}:
   state-icon-color: "#FFF"
   state-icon-active-color: {{ state_icon_active_color }}  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: {{ state_icon_active_color }}  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: {{ paper_slider_active_color }}  # from Apple systemBlue {{ which }} mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -44,27 +36,19 @@ ios-{{ which }}-mode-{{ color }}{{ suffix }}:
   label-badge-red: {{ label_badge_red }}  # from Apple systemOrange {{ which }} mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: {{  ha_card_background }}
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: {{ rgb_card_background }} # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: {{ switch_checked_track_color }}  # from Apple systemGreen {{ which }} mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: {{ paper_dialog_background_color }}  # e.g., background of more-info
-  paper-item-icon-color: {{ paper_item_icon_color }}  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: {{ dialog_background_color }}  # e.g., background of more-info dialogs
   more-info-header-background: {{ more_info_header_background }}
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: {{ app_header_background_color }}
@@ -75,14 +59,4 @@ ios-{{ which }}-mode-{{ color }}{{ suffix }}:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)

--- a/template.jinja2
+++ b/template.jinja2
@@ -52,6 +52,9 @@ ios-{{ which }}-mode-{{ color }}{{ suffix }}:
   more-info-header-background: {{ more_info_header_background }}
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: {{ app_header_background_color }}
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: {{ markdown_code_background_color }}
   code-editor-background-color: {{ code_editor_background_color }}
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64

--- a/themes/ios-themes.yaml
+++ b/themes/ios-themes.yaml
@@ -54,6 +54,9 @@ ios-light-mode-blue-red-alternative:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(30, 2, 61, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -117,6 +120,9 @@ ios-light-mode-blue-red:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(30, 2, 61, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -180,6 +186,9 @@ ios-dark-mode-blue-red-alternative:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(30, 2, 61, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -243,6 +252,9 @@ ios-dark-mode-blue-red:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(30, 2, 61, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -306,6 +318,9 @@ ios-light-mode-dark-blue-alternative:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 69, 124, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -369,6 +384,9 @@ ios-light-mode-dark-blue:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 69, 124, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -432,6 +450,9 @@ ios-dark-mode-dark-blue-alternative:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 69, 124, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -495,6 +516,9 @@ ios-dark-mode-dark-blue:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 69, 124, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -558,6 +582,9 @@ ios-light-mode-dark-green-alternative:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 89, 71, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -621,6 +648,9 @@ ios-light-mode-dark-green:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 89, 71, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -684,6 +714,9 @@ ios-dark-mode-dark-green-alternative:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 89, 71, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -747,6 +780,9 @@ ios-dark-mode-dark-green:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 89, 71, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -810,6 +846,9 @@ ios-light-mode-light-blue-alternative:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(1, 195, 220, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -873,6 +912,9 @@ ios-light-mode-light-blue:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(1, 195, 220, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -936,6 +978,9 @@ ios-dark-mode-light-blue-alternative:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(1, 195, 220, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -999,6 +1044,9 @@ ios-dark-mode-light-blue:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(1, 195, 220, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -1062,6 +1110,9 @@ ios-light-mode-light-green-alternative:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(114, 188, 139, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -1125,6 +1176,9 @@ ios-light-mode-light-green:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(114, 188, 139, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -1188,6 +1242,9 @@ ios-dark-mode-light-green-alternative:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(114, 188, 139, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -1251,6 +1308,9 @@ ios-dark-mode-light-green:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(114, 188, 139, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -1314,6 +1374,9 @@ ios-light-mode-orange-alternative:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(255, 229, 116, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -1377,6 +1440,9 @@ ios-light-mode-orange:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(255, 229, 116, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -1440,6 +1506,9 @@ ios-dark-mode-orange-alternative:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(255, 229, 116, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -1503,6 +1572,9 @@ ios-dark-mode-orange:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(255, 229, 116, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -1566,6 +1638,9 @@ ios-light-mode-red-alternative:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(234, 88, 63, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -1629,6 +1704,9 @@ ios-light-mode-red:
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(234, 88, 63, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#FFFFFF"
   code-editor-background-color: "#FFF"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -1692,6 +1770,9 @@ ios-dark-mode-red-alternative:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(234, 88, 63, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64
@@ -1755,6 +1836,9 @@ ios-dark-mode-red:
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(234, 88, 63, 0.4)
+  app-header-selection-bar-color: var(--accent-color)  # active view tab indicator bar (HA 2025.5+)
+  sl-color-primary-600: var(--accent-color)  # active view tab text/icon color (HA 2025.5+ sl-tab)
+  sl-color-neutral-600: var(--app-header-text-color)  # inactive view tab text/icon color (HA 2025.5+ sl-tab)
   markdown-code-background-color: "#464646"
   code-editor-background-color: "#161616"
   clear-background-color: var(--ha-card-background)  # see https://github.com/basnijholt/lovelace-ios-themes/issues/64

--- a/themes/ios-themes.yaml
+++ b/themes/ios-themes.yaml
@@ -30,15 +30,7 @@ ios-light-mode-blue-red-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -46,27 +38,19 @@ ios-light-mode-blue-red-alternative:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(30, 2, 61, 0.4)
@@ -77,16 +61,6 @@ ios-light-mode-blue-red-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -119,15 +93,7 @@ ios-light-mode-blue-red:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -135,27 +101,19 @@ ios-light-mode-blue-red:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(30, 2, 61, 0.4)
@@ -166,16 +124,6 @@ ios-light-mode-blue-red:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -208,15 +156,7 @@ ios-dark-mode-blue-red-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -224,27 +164,19 @@ ios-dark-mode-blue-red-alternative:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(30, 2, 61, 0.4)
@@ -255,16 +187,6 @@ ios-dark-mode-blue-red-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -297,15 +219,7 @@ ios-dark-mode-blue-red:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -313,27 +227,19 @@ ios-dark-mode-blue-red:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(30, 2, 61, 0.4)
@@ -344,16 +250,6 @@ ios-dark-mode-blue-red:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -386,15 +282,7 @@ ios-light-mode-dark-blue-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -402,27 +290,19 @@ ios-light-mode-dark-blue-alternative:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 69, 124, 0.4)
@@ -433,16 +313,6 @@ ios-light-mode-dark-blue-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -475,15 +345,7 @@ ios-light-mode-dark-blue:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -491,27 +353,19 @@ ios-light-mode-dark-blue:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 69, 124, 0.4)
@@ -522,16 +376,6 @@ ios-light-mode-dark-blue:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -564,15 +408,7 @@ ios-dark-mode-dark-blue-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -580,27 +416,19 @@ ios-dark-mode-dark-blue-alternative:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 69, 124, 0.4)
@@ -611,16 +439,6 @@ ios-dark-mode-dark-blue-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -653,15 +471,7 @@ ios-dark-mode-dark-blue:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -669,27 +479,19 @@ ios-dark-mode-dark-blue:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 69, 124, 0.4)
@@ -700,16 +502,6 @@ ios-dark-mode-dark-blue:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -742,15 +534,7 @@ ios-light-mode-dark-green-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -758,27 +542,19 @@ ios-light-mode-dark-green-alternative:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 89, 71, 0.4)
@@ -789,16 +565,6 @@ ios-light-mode-dark-green-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -831,15 +597,7 @@ ios-light-mode-dark-green:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -847,27 +605,19 @@ ios-light-mode-dark-green:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 89, 71, 0.4)
@@ -878,16 +628,6 @@ ios-light-mode-dark-green:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -920,15 +660,7 @@ ios-dark-mode-dark-green-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -936,27 +668,19 @@ ios-dark-mode-dark-green-alternative:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 89, 71, 0.4)
@@ -967,16 +691,6 @@ ios-dark-mode-dark-green-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -1009,15 +723,7 @@ ios-dark-mode-dark-green:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -1025,27 +731,19 @@ ios-dark-mode-dark-green:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(48, 89, 71, 0.4)
@@ -1056,16 +754,6 @@ ios-dark-mode-dark-green:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -1098,15 +786,7 @@ ios-light-mode-light-blue-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -1114,27 +794,19 @@ ios-light-mode-light-blue-alternative:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(1, 195, 220, 0.4)
@@ -1145,16 +817,6 @@ ios-light-mode-light-blue-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -1187,15 +849,7 @@ ios-light-mode-light-blue:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -1203,27 +857,19 @@ ios-light-mode-light-blue:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(1, 195, 220, 0.4)
@@ -1234,16 +880,6 @@ ios-light-mode-light-blue:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -1276,15 +912,7 @@ ios-dark-mode-light-blue-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -1292,27 +920,19 @@ ios-dark-mode-light-blue-alternative:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(1, 195, 220, 0.4)
@@ -1323,16 +943,6 @@ ios-dark-mode-light-blue-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -1365,15 +975,7 @@ ios-dark-mode-light-blue:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -1381,27 +983,19 @@ ios-dark-mode-light-blue:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(1, 195, 220, 0.4)
@@ -1412,16 +1006,6 @@ ios-dark-mode-light-blue:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -1454,15 +1038,7 @@ ios-light-mode-light-green-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -1470,27 +1046,19 @@ ios-light-mode-light-green-alternative:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(114, 188, 139, 0.4)
@@ -1501,16 +1069,6 @@ ios-light-mode-light-green-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -1543,15 +1101,7 @@ ios-light-mode-light-green:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -1559,27 +1109,19 @@ ios-light-mode-light-green:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(114, 188, 139, 0.4)
@@ -1590,16 +1132,6 @@ ios-light-mode-light-green:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -1632,15 +1164,7 @@ ios-dark-mode-light-green-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -1648,27 +1172,19 @@ ios-dark-mode-light-green-alternative:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(114, 188, 139, 0.4)
@@ -1679,16 +1195,6 @@ ios-dark-mode-light-green-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -1721,15 +1227,7 @@ ios-dark-mode-light-green:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -1737,27 +1235,19 @@ ios-dark-mode-light-green:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(114, 188, 139, 0.4)
@@ -1768,16 +1258,6 @@ ios-dark-mode-light-green:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -1810,15 +1290,7 @@ ios-light-mode-orange-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -1826,27 +1298,19 @@ ios-light-mode-orange-alternative:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(255, 229, 116, 0.4)
@@ -1857,16 +1321,6 @@ ios-light-mode-orange-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -1899,15 +1353,7 @@ ios-light-mode-orange:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -1915,27 +1361,19 @@ ios-light-mode-orange:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(255, 229, 116, 0.4)
@@ -1946,16 +1384,6 @@ ios-light-mode-orange:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -1988,15 +1416,7 @@ ios-dark-mode-orange-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -2004,27 +1424,19 @@ ios-dark-mode-orange-alternative:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(255, 229, 116, 0.4)
@@ -2035,16 +1447,6 @@ ios-dark-mode-orange-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -2077,15 +1479,7 @@ ios-dark-mode-orange:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -2093,27 +1487,19 @@ ios-dark-mode-orange:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(255, 229, 116, 0.4)
@@ -2124,16 +1510,6 @@ ios-dark-mode-orange:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -2166,15 +1542,7 @@ ios-light-mode-red-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#333333"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#333333"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -2182,27 +1550,19 @@ ios-light-mode-red-alternative:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(234, 88, 63, 0.4)
@@ -2213,16 +1573,6 @@ ios-light-mode-red-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -2255,15 +1605,7 @@ ios-light-mode-red:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#007aff"  # from Apple systemBlue light mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -2271,27 +1613,19 @@ ios-light-mode-red:
   label-badge-red: rgba(255, 149, 9, 0.7)  # from Apple systemOrange light mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(245, 245, 245, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(245, 245, 245) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#34c759"  # from Apple systemGreen light mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: "#333333"  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(200, 200, 200, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(230, 230, 230, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(234, 88, 63, 0.4)
@@ -2302,16 +1636,6 @@ ios-light-mode-red:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -2344,15 +1668,7 @@ ios-dark-mode-red-alternative:
   state-icon-color: "#FFF"
   state-icon-active-color: "#FFF"  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: "#FFF"  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -2360,27 +1676,19 @@ ios-dark-mode-red-alternative:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(234, 88, 63, 0.4)
@@ -2391,16 +1699,6 @@ ios-dark-mode-red-alternative:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)
 
 #
@@ -2433,15 +1731,7 @@ ios-dark-mode-red:
   state-icon-color: "#FFF"
   state-icon-active-color: rgba(255, 214, 10, 1)  # or make light icons yellow when active: rgba(255, 214, 10, 1)
   state-icon-unavailable-color: var(--disabled-text-color)
-  paper-item-icon-active-color: rgba(255, 214, 10, 1)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/30
-  # Sliders
-  paper-slider-knob-color: "#FFFFFF"
-  paper-slider-knob-start-color: var(--paper-slider-knob-color)
-  paper-slider-pin-color: var(--paper-slider-knob-color)
-  paper-slider-active-color: "#0984ff"  # from Apple systemBlue dark mode
-  paper-slider-secondary-color: var(--paper-slider-knob-color)
-  paper-slider-container-color: rgba(255, 255, 255, 0.5)
-  paper-slider-font-color: "#000"
+  # Sliders (paper-slider-* removed in HA 2025.5; ha-slider follows primary/accent color)
   ha-slider-background: none !important
   # Labels
   label-badge-background-color: "#23232E"
@@ -2449,27 +1739,19 @@ ios-dark-mode-red:
   label-badge-red: rgba(255, 159, 9, 0.7)  # from Apple systemOrange dark mode
   # Cards
   card-background-color: var(--secondary-background-color)  # Unused entities table background
-  paper-listbox-background-color: var(--primary-background-color)
   ha-card-border-radius: 20px
   ha-card-background: rgba(10, 10, 10, 0.4)
-  paper-card-background-color: var(--ha-card-background)
   rgb-card-background-color: rgb(10, 10, 10) # see https://github.com/basnijholt/lovelace-ios-themes/issues/60
   ha-card-border-width: 0  # https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/82#event-7732695357
-  # Toggles
-  paper-toggle-button-checked-button-color: "#484848"
-  paper-toggle-button-checked-bar-color: "#484848"
-  paper-toggle-button-unchecked-button-color: var(--paper-toggle-button-checked-button-color)
-  paper-toggle-button-unchecked-bar-color: var(--disabled-text-color)
   # Table row
   table-row-background-color: var(--primary-background-color)
   table-row-alternative-background-color: var(--secondary-background-color)
-  # Switches
-  switch-checked-color: "#30d257"  # XXX: remove when https://github.com/home-assistant/home-assistant-polymer/pull/4203 is in HA
+  # Switches (paper-toggle-button-* removed in HA 2025.5)
+  switch-checked-color: "#30d257"
   switch-checked-track-color: "#30d158"  # from Apple systemGreen dark mode
   switch-checked-button-color: "#FFF"
   # Other
-  paper-dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info
-  paper-item-icon-color: white  # also should mini-media-player icon white (but doesn't work by itself)
+  dialog-background-color: rgba(55, 55, 55, 0.8)  # e.g., background of more-info dialogs
   more-info-header-background: rgba(25, 25, 25, 0.5)
   lumo-body-text-color: var(--primary-text-color)  # see https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/42
   app-header-background-color: rgba(234, 88, 63, 0.4)
@@ -2480,14 +1762,4 @@ ios-dark-mode-red:
   mcg-title-letter-spacing: .15em
   mini-media-player-base-color: white
   mini-media-player-icon-color: white
-  # Added for https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  # TODO: add description for lines below. Suggested in https://github.com/basnijholt/lovelace-ios-dark-mode-theme/issues/72
-  input-ink-color: var(--primary-text-color)
-  input-fill-color: transparent
-  input-disabled-fill-color: transparent
-  input-label-ink-color: var(--primary-text-color)
-  input-disabled-ink-color: var(--disabled-text-color)
-  input-dropdown-icon-color: var(--primary-text-color)
-  input-idle-line-color: var(--secondary-text-color)
-  input-hover-line-color: var(--secondary-text-color)
   codemirror-property: var(--accent-color)


### PR DESCRIPTION
## Summary

This PR modernizes the theme for Home Assistant 2025.5+ by removing all
deprecated Polymer/paper-* variables, migrating one renamed variable, and
adding support for the new sl-tab view tab components. The README has also
been updated for HACS 2.0 and current HA dashboard conventions.

All changes are in `template.jinja2` and `settings-light-dark.yaml`.
The generated `themes/ios-themes.yaml` has been regenerated accordingly.

## Changes

### Removed (paper-* removed in HA 2025.5)
- `paper-slider-*` — sliders now follow `--primary-color`/`--accent-color` automatically
- `paper-toggle-button-*` — switches already use `switch-checked-*`
- `paper-listbox-background-color`
- `paper-card-background-color`
- `paper-item-icon-color` / `paper-item-icon-active-color`
- Vaadin `--vaadin-text-field-*` input variables
- Stale `# XXX: remove when .../pull/4203 is in HA` comment

### Updated
- `paper-dialog-background-color` → `dialog-background-color`

### Added (HA 2025.5+ sl-tab view tabs)
- `app-header-selection-bar-color` — active view tab indicator bar
- `sl-color-primary-600` — active view tab text/icon colour
- `sl-color-neutral-600` — inactive view tab text/icon colour

### README
- Updated HACS installation steps for HACS 2.0 UI
- Updated background setup instructions for current HA dashboard UI
  (replaces references to legacy `lovelace-ui.yaml`)
- Updated Automations section: softened WARNING, added UI Helpers path,
  updated terminology (Lovelace → dashboard)
- Added HA 2025.5+ compatibility section documenting all the above changes

## Testing
Tested on Home Assistant 2026.3.x with all 7 backgrounds in both light
and dark mode. All 28 theme variants confirmed working.